### PR TITLE
Make a security group for the example lambda function

### DIFF
--- a/lpa_status_lambda.tf
+++ b/lpa_status_lambda.tf
@@ -1,5 +1,28 @@
-data "aws_security_group" "default" {
-  id = "sg-10537c76"
+data "aws_vpc" "vpc" {
+  filter {
+    name   = "tag:Stack"
+    values = ["${local.vpc_name}"]
+  }
+}
+
+resource "aws_security_group" "lpa_status_allow_all" {
+  name        = "lpa_status-allow_all"
+  description = "Allow all inbound traffic"
+  vpc_id      = "${data.aws_vpc.vpc.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 
 data "archive_file" "lpa_status_lambda_archive" {
@@ -16,7 +39,7 @@ module "lpa_status" {
   lambda_runtime           = "python3.7"
 
   security_group_ids = [
-    "${data.aws_security_group.default.id}",
+    "${aws_security_group.lpa_status_allow_all.id}",
   ]
 
   vpc                          = "${local.vpc_name}"

--- a/modules/api_gateway_lambda_function/main.tf
+++ b/modules/api_gateway_lambda_function/main.tf
@@ -16,8 +16,7 @@ data "aws_subnet" "private" {
   }
 }
 
-# Lambda Function IAM Stuff
-
+# Lambda Function IAM
 resource "aws_iam_role" "iam_for_lambda" {
   name               = "${var.lambda_name}-invoke"
   assume_role_policy = "${data.aws_iam_policy_document.lambda_assume.json}"
@@ -45,7 +44,6 @@ data "aws_iam_policy_document" "lambda_assume" {
 }
 
 # Lambda Function
-
 resource "aws_lambda_function" "lambda_function" {
   function_name = "${var.lambda_name}"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
@@ -119,7 +117,6 @@ resource "aws_api_gateway_deployment" "deployment" {
 }
 
 # OPG API Gateway Access Policy
-
 resource "aws_iam_role" "opg_api_endpoint_access" {
   name               = "opg_api_endpoint_access"
   assume_role_policy = "${data.aws_iam_policy_document.cross_account_access_lpa.json}"
@@ -149,7 +146,6 @@ data "aws_iam_policy_document" "opg_api_endpoint_access" {
 }
 
 # Cross account roles that can access this lambda/endpoint
-
 data "aws_iam_policy_document" "cross_account_access_lpa" {
   statement {
     sid = "CrossAccountApiGatewayAccessPolicy"

--- a/techdebt.md
+++ b/techdebt.md
@@ -8,3 +8,6 @@
 - Move make zip into module and ask for path only
 - create security group instead of using an existing one
 - ~~Add README for module~~
+- interpolate the vpc name and id from a data source
+- ~~output security group from module for use elsewhere~~
+- log to cloudwatch


### PR DESCRIPTION
# Description

Created a security group for a lambda function in each workspace.
This has been done outside of the module so that security groups can be configured to meet that lambda functions needs without passing complicated variables into the module.

# Issues Resolved

Previously, a specific security group was being used that wasn't available across accounts and workspaces.

# Contribution Checklist

- [X] Terraform plans
- [X] New functionality has been documented in the README if applicable
