### PR TITLE
Grant access for LPA API2 roles to the API Gateway lpa-online-tool resource (based on stack/account)

### DIFF
--- a/api-gateway.tf
+++ b/api-gateway.tf
@@ -36,9 +36,27 @@ resource "aws_iam_role_policy_attachment" "log_to_cloudwatch" {
 resource "aws_api_gateway_rest_api" "opg_api_gateway" {
   name        = "opg-sirius-api-gateway-${terraform.workspace}"
   description = "OPG Sirius API Gateway - ${terraform.workspace}"
+  policy      = "${data.aws_iam_policy_document.resource_policy.json}"
 
   endpoint_configuration {
     types = ["REGIONAL"]
+  }
+}
+
+data "aws_iam_policy_document" "resource_policy" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      identifiers = [
+        "${local.api_gateway_allowed_roles}",
+      ]
+
+      type = "AWS"
+    }
+
+    actions   = ["execute-api:Invoke"]
+    resources = ["arn:aws:execute-api:${data.aws_region.current.name}:${local.target_account}:*/*/*/*"]
   }
 }
 

--- a/api-gateway.tf
+++ b/api-gateway.tf
@@ -45,18 +45,19 @@ resource "aws_api_gateway_rest_api" "opg_api_gateway" {
 
 data "aws_iam_policy_document" "resource_policy" {
   statement {
+    sid    = "onlinelpaaccess"
     effect = "Allow"
 
     principals {
       identifiers = [
-        "${local.api_gateway_allowed_roles}",
+        "${local.api_gateway_allowed_roles_online_lpa_tool}",
       ]
 
       type = "AWS"
     }
 
     actions   = ["execute-api:Invoke"]
-    resources = ["arn:aws:execute-api:${data.aws_region.current.name}:${local.target_account}:*/*/*/*"]
+    resources = ["arn:aws:execute-api:${data.aws_region.current.name}:${local.target_account}:*/*/GET/lpa-online-tool/lpas/*"]
   }
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -11,61 +11,47 @@ locals {
   }
 
   account_names = {
-    "production" = "sirius-production"
-
-    # "preproduction" = "sirius-production"
+    "production"  = "sirius-production"
     "development" = "sirius-development"
   }
 
   vpcs = {
-    "production" = "prod-vpc"
-
-    # "preproduction" = "prod-vpc"
+    "production"  = "prod-vpc"
     "development" = "dev-vpc"
   }
 
   vpc_name = "${lookup(local.vpcs, terraform.workspace)}"
 
   membrane_client_security_groups = {
-    "production" = "membrane-client-production"
-
-    # "preproduction" = "membrane-client-preprod"
+    "production"  = "membrane-client-production"
     "development" = "membrane-client-feature"
   }
 
   membrane_client_security_group_name = "${lookup(local.membrane_client_security_groups, terraform.workspace)}"
 
   membrane_hostnames = {
-    "production" = "membrane.production.internal"
-
-    # "preproduction" = "membrane.preprod.internal"
+    "production"  = "membrane.production.internal"
     "development" = "membrane.feature.internal"
   }
 
   membrane_hostname = "${lookup(local.membrane_hostnames, terraform.workspace)}"
 
   target_accounts = {
-    "production" = "649098267436"
-
-    # "preproduction" = "649098267436"
+    "production"  = "649098267436"
     "development" = "288342028542"
   }
 
   target_account = "${lookup(local.target_accounts, terraform.workspace)}"
 
   opg_sirius_hosted_zones = {
-    "production" = "sirius.opg.digital"
-
-    # "preproduction" = "sirius.opg.digital"
+    "production"  = "sirius.opg.digital"
     "development" = "dev.sirius.opg.digital"
   }
 
   opg_sirius_hosted_zone = "${lookup(local.opg_sirius_hosted_zones, terraform.workspace)}"
 
   is_production = {
-    "production" = "true"
-
-    # "preproduction" = "false"
+    "production"  = "true"
     "development" = "false"
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -55,10 +55,22 @@ locals {
     "development" = "false"
   }
 
-  lpa_sources_dev  = ["arn:aws:iam::001780581745:role/api2.qa", "arn:aws:iam::001780581745:role/api2.staging04"]
-  lpa_sources_prod = ["arn:aws:iam::001780581745:role/api2.production04", "arn:aws:iam::001780581745:role/api2.preprod"]
+  development_api_gateway_allowed_roles = [
+    "arn:aws:iam::001780581745:role/api2.qa",
+    "arn:aws:iam::001780581745:role/api2.staging04",
+  ]
 
-  lpa_tool_api2_role = "${split(",", terraform.workspace == "development" ? join(",", local.lpa_sources_dev) : join(",", local.lpa_sources_prod))}"
+  production_api_gateway_allowed_roles = [
+    "arn:aws:iam::001780581745:role/api2.production04",
+    "arn:aws:iam::001780581745:role/api2.preprod",
+  ]
+
+  api_gateway_allowed_roles = "${split(",", terraform.workspace == "development" ? join(",", local.development_api_gateway_allowed_roles) : join(",", local.production_api_gateway_allowed_roles))}"
+
+  api_gateway_allowed_users = [
+    "arn:aws:iam::631181914621:user/andrew.pearce",
+    "arn:aws:iam::631181914621:user/neil.smith",
+  ]
 
   default_tags = {
     business-unit          = "OPG"

--- a/locals.tf
+++ b/locals.tf
@@ -55,17 +55,17 @@ locals {
     "development" = "false"
   }
 
-  development_api_gateway_allowed_roles = [
+  online_lpa_tool_development_api_gateway_allowed_roles = [
     "arn:aws:iam::001780581745:role/api2.qa",
     "arn:aws:iam::001780581745:role/api2.staging04",
   ]
 
-  production_api_gateway_allowed_roles = [
+  online_lpa_tool_production_api_gateway_allowed_roles = [
     "arn:aws:iam::001780581745:role/api2.production04",
     "arn:aws:iam::001780581745:role/api2.preprod",
   ]
 
-  api_gateway_allowed_roles = "${split(",", terraform.workspace == "development" ? join(",", local.development_api_gateway_allowed_roles) : join(",", local.production_api_gateway_allowed_roles))}"
+  api_gateway_allowed_roles_online_lpa_tool = "${split(",", terraform.workspace == "development" ? join(",", local.online_lpa_tool_development_api_gateway_allowed_roles) : join(",", local.online_lpa_tool_production_api_gateway_allowed_roles))}"
 
   api_gateway_allowed_users = [
     "arn:aws:iam::631181914621:user/andrew.pearce",

--- a/locals.tf
+++ b/locals.tf
@@ -11,56 +11,68 @@ locals {
   }
 
   account_names = {
-    "production"    = "sirius-production"
-    "preproduction" = "sirius-production"
-    "development"   = "sirius-development"
+    "production" = "sirius-production"
+
+    # "preproduction" = "sirius-production"
+    "development" = "sirius-development"
   }
 
   vpcs = {
-    "production"    = "prod-vpc"
-    "preproduction" = "prod-vpc"
-    "development"   = "dev-vpc"
+    "production" = "prod-vpc"
+
+    # "preproduction" = "prod-vpc"
+    "development" = "dev-vpc"
   }
 
   vpc_name = "${lookup(local.vpcs, terraform.workspace)}"
 
   membrane_client_security_groups = {
-    "production"    = "membrane-client-production"
-    "preproduction" = "membrane-client-preprod"
-    "development"   = "membrane-client-feature"
+    "production" = "membrane-client-production"
+
+    # "preproduction" = "membrane-client-preprod"
+    "development" = "membrane-client-feature"
   }
 
   membrane_client_security_group_name = "${lookup(local.membrane_client_security_groups, terraform.workspace)}"
 
   membrane_hostnames = {
-    "production"    = "membrane.production.internal"
-    "preproduction" = "membrane.preprod.internal"
-    "development"   = "membrane.feature.internal"
+    "production" = "membrane.production.internal"
+
+    # "preproduction" = "membrane.preprod.internal"
+    "development" = "membrane.feature.internal"
   }
 
   membrane_hostname = "${lookup(local.membrane_hostnames, terraform.workspace)}"
 
   target_accounts = {
-    "production"    = "649098267436"
-    "preproduction" = "649098267436"
-    "development"   = "288342028542"
+    "production" = "649098267436"
+
+    # "preproduction" = "649098267436"
+    "development" = "288342028542"
   }
 
   target_account = "${lookup(local.target_accounts, terraform.workspace)}"
 
   opg_sirius_hosted_zones = {
-    "production"    = "sirius.opg.digital"
-    "preproduction" = "sirius.opg.digital"
-    "development"   = "dev.sirius.opg.digital"
+    "production" = "sirius.opg.digital"
+
+    # "preproduction" = "sirius.opg.digital"
+    "development" = "dev.sirius.opg.digital"
   }
 
   opg_sirius_hosted_zone = "${lookup(local.opg_sirius_hosted_zones, terraform.workspace)}"
 
   is_production = {
-    "production"    = "true"
-    "preproduction" = "false"
-    "development"   = "false"
+    "production" = "true"
+
+    # "preproduction" = "false"
+    "development" = "false"
   }
+
+  lpa_sources_dev  = ["arn:aws:iam::001780581745:role/api2.qa", "arn:aws:iam::001780581745:role/api2.staging04"]
+  lpa_sources_prod = ["arn:aws:iam::001780581745:role/api2.production04", "arn:aws:iam::001780581745:role/api2.preprod"]
+
+  lpa_tool_api2_role = "${split(",", terraform.workspace == "development" ? join(",", local.lpa_sources_dev) : join(",", local.lpa_sources_prod))}"
 
   default_tags = {
     business-unit          = "OPG"

--- a/lpas_collection.tf
+++ b/lpas_collection.tf
@@ -23,14 +23,14 @@ module "lpas_collection_lambda" {
 
   security_group_ids = [
     "${aws_security_group.lambda.id}",
-    "${data.aws_security_group.membrane_client.id}"
+    "${data.aws_security_group.membrane_client.id}",
   ]
 
   vpc = "${local.vpc_name}"
 
   environment {
     variables {
-      CREDENTIALS = "${data.aws_secretsmanager_secret_version.sirius_credentials.secret_string}"
+      CREDENTIALS  = "${data.aws_secretsmanager_secret_version.sirius_credentials.secret_string}"
       URL_MEMBRANE = "https://${local.membrane_hostname}"
     }
   }

--- a/products.tf
+++ b/products.tf
@@ -21,7 +21,6 @@ data "aws_iam_policy_document" "lpa_online_tool_role_cross_account_policy" {
       type = "AWS"
 
       identifiers = [
-        "${local.api_gateway_allowed_roles}",
         "${local.api_gateway_allowed_users}",
       ]
     }

--- a/products.tf
+++ b/products.tf
@@ -22,10 +22,7 @@ data "aws_iam_policy_document" "lpa_online_tool_role_cross_account_policy" {
 
       identifiers = [
         "${local.lpa_tool_api2_role}",
-
-        # "${local.lpa_sources_dev}",
         "arn:aws:iam::631181914621:user/andrew.pearce",
-
         "arn:aws:iam::631181914621:user/neil.smith",
       ]
     }

--- a/products.tf
+++ b/products.tf
@@ -21,8 +21,11 @@ data "aws_iam_policy_document" "lpa_online_tool_role_cross_account_policy" {
       type = "AWS"
 
       identifiers = [
-        "arn:aws:iam::${lookup(local.accounts, "lpa-development")}:role/api2.staging04",
+        "${local.lpa_tool_api2_role}",
+
+        # "${local.lpa_sources_dev}",
         "arn:aws:iam::631181914621:user/andrew.pearce",
+
         "arn:aws:iam::631181914621:user/neil.smith",
       ]
     }

--- a/products.tf
+++ b/products.tf
@@ -21,9 +21,8 @@ data "aws_iam_policy_document" "lpa_online_tool_role_cross_account_policy" {
       type = "AWS"
 
       identifiers = [
-        "${local.lpa_tool_api2_role}",
-        "arn:aws:iam::631181914621:user/andrew.pearce",
-        "arn:aws:iam::631181914621:user/neil.smith",
+        "${local.api_gateway_allowed_roles}",
+        "${local.api_gateway_allowed_users}",
       ]
     }
   }


### PR DESCRIPTION
# Description

Grant assume role access to Online LPA Tool API2 instances

# Issues Resolved

I had hoped to add the instance roles as principles to the gateway access policy but couldn't get it to work.

Instead this extends the assume role policy princples, meaning the Online LPA Tool will need to assume a role to communicate with the gateway.

# Contribution Checklist

- [X] Terraform plans
```~ aws_api_gateway_rest_api.opg_api_gateway
    policy:   {
                     "Action": "execute-api:Invoke",
                     "Effect": "Allow",
                     "Principal": {
                       "AWS": [
              +          "arn:aws:iam::001780581745:role/api2.staging04",
              +          "arn:aws:iam::001780581745:role/api2.qa"
                       ]
                     },
              +      "Resource": "arn:aws:execute-api:eu-west-1:288342028542:*/*/GET/lpa-online-tool/lpas/*",
              +      "Sid": "onlinelpaaccess"
                   }
                 ],
                 "Version": "2012-10-17"
               }
```