### PR TITLE
LPA 3157: Gateway cache auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@
 api-gateway/
 .venv
 
-# lambda zip
+# lambda stuff
+/lambdas/vendor
 lambda_artifact.zip
 
 # Ruby
@@ -22,3 +23,4 @@ __pycache__
 
 # Test environment
 *generated.postman_environment.json
+

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OPG API Gateway into Sirius: Managed by opg-org-infra &amp; Terraform
 [![CircleCI](https://circleci.com/gh/ministryofjustice/opg-sirius-api-gateway/tree/master.svg?style=svg)](https://circleci.com/gh/ministryofjustice/opg-sirius-api-gateway/tree/master)
 
 
-## Working localling with Terraform
+## Working locally with Terraform
 
 ### Setting Env Vars
 
@@ -110,3 +110,19 @@ Run a test against development
 ```bash
 aws-vault exec identity -- bundle exec rake lambda:testlpas
 ```
+
+#Setup for local development
+
+For testing _with_ the full local Sirius stack, you need to bring OPG Gateway up at the same time as Sirius.
+Ensure that `opg-sirius-api-gateway` is cloned into the same root direct as `opgs-sirius`.
+
+Then **from within `opgs-sirius`**, run:
+
+```bash
+docker-compose -f docker-compose.yml \
+-f docker-compose.override.yml \
+-f ../opg-sirius-api-gateway/docker-compose.yml \
+-f ../opg-sirius-api-gateway/docker-compose-sirius.yml up
+```
+
+This will give you the normal Sirius stack, plus OPG Gateway (and its dependencies).

--- a/api-gateway.tf
+++ b/api-gateway.tf
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "resource_policy" {
 
     actions   = ["execute-api:Invoke"]
 
-    // API Gateway will add all of teh result of the ARN details in for us. Provents a circular dependency.
+    // API Gateway will add all of the rest of the ARN details in for us. Provents a circular dependency.
     resources = ["execute-api:/*/GET/lpa-online-tool/*"]
   }
 }

--- a/api-gateway.tf
+++ b/api-gateway.tf
@@ -57,16 +57,18 @@ data "aws_iam_policy_document" "resource_policy" {
     }
 
     actions   = ["execute-api:Invoke"]
-    resources = ["arn:aws:execute-api:${data.aws_region.current.name}:${local.target_account}:*/*/GET/lpa-online-tool/lpas/*"]
+
+    // API Gateway will add all of teh result of the ARN details in for us. Provents a circular dependency.
+    resources = ["execute-api:/*/GET/lpa-online-tool/*"]
   }
 }
 
 //------------------------------------
 // Deploy the gateway
 
-resource "aws_api_gateway_deployment" "deployment" {
+resource "aws_api_gateway_deployment" "deployment_v1" {
   rest_api_id = "${aws_api_gateway_rest_api.opg_api_gateway.id}"
-  stage_name  = "testing"
+  stage_name  = "v1"
 
   // The policy is dependent on the module completing, so we can depend on that to mean everything is in place
   depends_on = ["aws_iam_role_policy_attachment.lpa_online_tool_get_lpas_id_access_policy"]
@@ -86,7 +88,7 @@ resource "aws_api_gateway_deployment" "deployment" {
 
 resource "aws_api_gateway_method_settings" "global_gateway_settings" {
   rest_api_id = "${aws_api_gateway_rest_api.opg_api_gateway.id}"
-  stage_name  = "${aws_api_gateway_deployment.deployment.stage_name}"
+  stage_name  = "${aws_api_gateway_deployment.deployment_v1.stage_name}"
   method_path = "*/*"
 
   settings {
@@ -106,9 +108,9 @@ resource "aws_api_gateway_domain_name" "opg_api_gateway" {
 
 resource "aws_api_gateway_base_path_mapping" "mapping" {
   api_id      = "${aws_api_gateway_rest_api.opg_api_gateway.id}"
-  stage_name  = "${aws_api_gateway_deployment.deployment.stage_name}"
+  stage_name  = "${aws_api_gateway_deployment.deployment_v1.stage_name}"
   domain_name = "${aws_api_gateway_domain_name.opg_api_gateway.domain_name}"
-  base_path   = "${aws_api_gateway_deployment.deployment.stage_name}"
+  base_path   = "${aws_api_gateway_deployment.deployment_v1.stage_name}"
 }
 
 data "aws_route53_zone" "sirius_opg_digital" {

--- a/docker-compose-sirius.yml
+++ b/docker-compose-sirius.yml
@@ -1,0 +1,21 @@
+version: '2.1'
+
+services:
+  gateway:
+    volumes:
+      - ../opg-sirius-api-gateway/docker:/srv/docker:cached
+      - ../opg-sirius-api-gateway/lambdas:/srv/lambdas:cached
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      LAMBDAS_PATH: ${PWD}/../opg-sirius-api-gateway/lambdas
+      # Keys starting 'PASSTHROUGH' are passed (sans 'PASSTHROUGH') to the actual Lambda.
+      PASSTHROUGH_URL_MEMBRANE: https://membrane
+      # Non-secret credentials, deliberately committed.
+      PASSTHROUGH_CREDENTIALS: '{"email": "publicapi@opgtest.com","password": "Password1"}'
+
+  localstack-config:
+    build:
+      context: ../opg-sirius-api-gateway/
+    volumes:
+      - ../opg-sirius-api-gateway/localstack-config:/config
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2.1'
 
 services:
   gateway:
@@ -13,7 +13,28 @@ services:
     ports:
       - 5000:5000
     environment:
-      - LAMBDAS_PATH=${PWD}/lambdas
+      LAMBDAS_PATH: ${PWD}/lambdas
+      # Keys starting 'PASSTHROUGH' are passed (sans 'PASSTHROUGH') to the actual Lambda.
+      PASSTHROUGH_DYNAMODB_AUTH_CACHE_TABE_NAME: opg-gateway-cache-auth
+      PASSTHROUGH_AWS_ENDPOINT_DYNAMODB: http://gateway-localstack:4569
+
+  gateway-localstack:
+    image: localstack/localstack
+    ports:
+      - 4569:4569
+    environment:
+      - SERVICES=dynamodb:4569
+      - DEFAULT_REGION=eu-west-1
+      - HOSTNAME=gateway-localstack
+
+  localstack-config:
+    build:
+      context: .
+      dockerfile: localstack-config/Dockerfile
+    volumes:
+      - ./localstack-config:/config
+    depends_on:
+      - gateway-localstack
 
   lambci:
     container_name: lambci-python

--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -1,0 +1,12 @@
+
+resource "aws_dynamodb_table" "auth_cache" {
+  name          = "opg-gateway-cache-auth"
+  billing_mode  = "PAY_PER_REQUEST"
+
+  hash_key       = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+}

--- a/lambdas/.gitignore
+++ b/lambdas/.gitignore
@@ -1,2 +1,3 @@
 /.venv
 /.pytest_cache
+/vendor

--- a/lambdas/data_providers/sirius/authentication.py
+++ b/lambdas/data_providers/sirius/authentication.py
@@ -2,6 +2,8 @@ import os
 import json
 import requests
 import urllib3
+import boto3
+import logging
 from . import SiriusAuthenticationError
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -10,30 +12,85 @@ class SiriusAuthenticator:
 
     """
     Given a Request object, decorate it with the required token header.
-    In its current form a new authentication token will be acquired for each data lookup.
+
+    Typically you should call authorise_request() with accept_cached_token = True in the first instance.
+    If the returned token turns out to be stale, then recall authorise_request() with accept_cached_token = False.
     """
 
     @staticmethod
     def factory():
         if 'CREDENTIALS' not in os.environ:
             raise RuntimeError('CREDENTIALS not set')
+
         if 'URL_MEMBRANE' not in os.environ:
             raise RuntimeError('URL_MEMBRANE not set')
 
+        if 'DYNAMODB_AUTH_CACHE_TABE_NAME' not in os.environ:
+            raise RuntimeError('DYNAMODB_AUTH_CACHE_TABE_NAME not set')
+
+        if 'AWS_ENDPOINT_DYNAMODB' in os.environ:
+            # For local development
+            dynamodb_endpoint_url = os.environ['AWS_ENDPOINT_DYNAMODB']
+            logging.debug('AWS_ENDPOINT_DYNAMODB set %s' % dynamodb_endpoint_url)
+        else:
+            # Should be none in AWS
+            dynamodb_endpoint_url = None
+
         credentials = json.loads(os.environ['CREDENTIALS'])
-        return SiriusAuthenticator(os.environ['URL_MEMBRANE'], credentials)
 
-    # --------------------
+        return SiriusAuthenticator(os.environ['URL_MEMBRANE'],
+                                   credentials,
+                                   os.environ['DYNAMODB_AUTH_CACHE_TABE_NAME'],
+                                   dynamodb_endpoint_url)
 
-    def __init__(self, membrane_url, credentials):
+    # ----------------------------------------------
+
+    def __init__(self, membrane_url, credentials, dynamodb_cache_table, dynamodb_endpoint_url):
         self._membrane_url = membrane_url
         self._credentials = credentials
+        self._dynamodb_cache_table = dynamodb_cache_table
+        self._dynamodb_endpoint_url = dynamodb_endpoint_url
 
-    def authorise_request(self, req):
-        req.headers['HTTP-SECURE-TOKEN'] = self._get_auth_token()
-        return req
+    def authorise_request(self, req, accept_cached_token):
 
-    def _get_auth_token(self):
+        """
+        Acquires an authentication token and decorates the request with it.
+            If `accept_cached_token` = True, we may return a token from the cache.
+            It may be stale. If authentication fails this method should be recalled with `accept_cached_token` = False
+
+            If `accept_cached_token` = True, but there's no token in DynamoDB, then we'll automatically recall
+            this method with `accept_cached_token` = True.
+
+            Whenever a new token is generated, it is stored in the cache.
+        """
+
+        session = boto3.Session()
+        dynamodb = session.resource('dynamodb', endpoint_url=self._dynamodb_endpoint_url)
+        cache_table = dynamodb.Table(self._dynamodb_cache_table)  # Is lazy
+
+        if accept_cached_token is True:
+
+            # We are looking up the token in DynamoDB.
+            # If there is no token, we return a fresh one.
+
+            result = self._get_cached_auth_token(cache_table)
+
+            # If we didn't get a cached token, automatically respond with a refresh token
+            if result is False:
+                logging.info('Failed to load a token from cache. Requesting a fresh one.')
+                return self.authorise_request(req, False)
+            else:
+                # Else we set the header
+                logging.info('Returning a cached token')
+                req.headers['HTTP-SECURE-TOKEN'] = result
+
+        else:
+            logging.info('Returning a fresh token')
+            req.headers['HTTP-SECURE-TOKEN'] = self._get_fresh_auth_token(cache_table)
+
+        return req, accept_cached_token
+
+    def _get_fresh_auth_token(self, cache_table):
         data = {'user': self._credentials}
 
         url = self._membrane_url + '/auth/sessions'
@@ -44,6 +101,33 @@ class SiriusAuthenticator:
         if r.status_code == 201:
             details = r.json()
             if 'authentication_token' in details:
+                # Add the new key into the cache
+                cache_table.put_item(
+                    Item={
+                        'id': 'token',
+                        'token': details['authentication_token'],
+                    }
+                )
                 return details['authentication_token']
 
         raise SiriusAuthenticationError()
+
+    def _get_cached_auth_token(self, cache_table):
+
+        """
+        Looks for a cached token in DynamoDB
+        """
+
+        response = cache_table.get_item(
+            Key={'id': 'token'}
+        )
+
+        if 'Item' not in response:
+            return False
+
+        item = response['Item']
+
+        if 'token' not in item:
+            return False
+
+        return item['token']

--- a/lambdas/data_providers/sirius/authentication.py
+++ b/lambdas/data_providers/sirius/authentication.py
@@ -64,8 +64,7 @@ class SiriusAuthenticator:
             Whenever a new token is generated, it is stored in the cache.
         """
 
-        session = boto3.Session()
-        dynamodb = session.resource('dynamodb', endpoint_url=self._dynamodb_endpoint_url)
+        dynamodb = boto3.resource('dynamodb', endpoint_url=self._dynamodb_endpoint_url)
         cache_table = dynamodb.Table(self._dynamodb_cache_table)  # Is lazy
 
         if accept_cached_token is True:

--- a/lambdas/data_providers/sirius_provider.py
+++ b/lambdas/data_providers/sirius_provider.py
@@ -3,6 +3,7 @@ from data_providers.sirius import SiriusAuthenticator, SiriusAuthenticationError
 from requests import Request, Session, exceptions
 from .model import Response
 from . import UpstreamExceptionError, UpstreamTimeoutError, InternalExceptionError
+import logging
 
 # --------------------------------------------
 # Responsible for looking up a given LPA from
@@ -23,20 +24,24 @@ class SiriusProvider:
 
     def get_lpa_by_lpa_online_tool_id(self, online_tool_id):
 
-        try:
-            s = Session()
+        logging.info("Sirius lookup of %s" % online_tool_id)
 
+        try:
             url = self._membrane_url + '/api/public/v1/lpas?lpa-online-tool-id=%s' % online_tool_id
 
-            req = Request('GET', url, headers={'host': 'membrane'}).prepare()
+            resp, cached_token = self._attempt_get(url=url, accept_cached_token=True)
 
-            # Decorate the request with an authentication token
-            req = self._authenticator.authorise_request(req)
+            # If we get a 401 Unauthorized, try again with the cached token
+            if resp.status_code == 401 and cached_token is True:
+                logging.warning('Lookup failed with cached token. Refreshing token.')
+                resp, cached_token = self._attempt_get(url=url, accept_cached_token=False)
 
-            resp = s.send(req, verify=False, timeout=(3.05, 5))
-
+            # If we get a 200, all is good. Return teh result.
             if resp.status_code == 200:
                 return Response.factory(online_tool_id, resp.text)
+
+            # If we reach here, all has failed.
+            raise UpstreamExceptionError('Sirius returned an unexpected response %d - %s', resp.status_code, resp.text)
 
         except SiriusAuthenticationError:
             raise InternalExceptionError('Sirius authentication error')
@@ -46,3 +51,12 @@ class SiriusProvider:
 
         except exceptions.RequestException as e:
             raise UpstreamExceptionError(e)
+
+    def _attempt_get(self, url, accept_cached_token):
+        s = Session()
+
+        req = Request('GET', url, headers={'host': 'membrane'}).prepare()
+
+        req, cached = self._authenticator.authorise_request(req, accept_cached_token=accept_cached_token)
+
+        return s.send(req, verify=False, timeout=(3.05, 5)), cached

--- a/lambdas/lpas_collection.py
+++ b/lambdas/lpas_collection.py
@@ -7,7 +7,7 @@ import json
 import logging
 
 logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 
 
 def id_handler(event, context):

--- a/lambdas/lpas_collection.py
+++ b/lambdas/lpas_collection.py
@@ -59,25 +59,25 @@ def id_handler(event, context):
         return response
 
     except InvalidInputError as e:
-        logger.error('InvalidInputError: %s' % e)
+        logging.error('InvalidInputError: %s' % e)
         return {'statusCode': 400, 'body': {
             'error': 'Bad request: %s' % e
         }}
 
     except InternalExceptionError as e:
-        logger.error('InternalExceptionError: %s' % e)
+        logging.error('InternalExceptionError: %s' % e)
         return {'statusCode': 500, 'body': {
             'error': 'An internal exception occurred. See Gateway logs for details.'
         }}
 
     except UpstreamExceptionError as e:
-        logger.error('UpstreamExceptionError: %s' % e)
+        logging.error('UpstreamExceptionError: %s' % e)
         return {'statusCode': 502, 'body': {
             'error': 'The upstream data provider returned an exception. See Gateway logs for details.'
         }}
 
     except UpstreamTimeoutError:
-        logger.warning('UpstreamTimeoutError')
+        logging.warning('UpstreamTimeoutError')
         return {'statusCode': 504, 'body': {
             'error': 'The upstream data provider timed out'
         }}

--- a/lambdas/requirements.txt
+++ b/lambdas/requirements.txt
@@ -1,1 +1,2 @@
 requests
+boto3

--- a/lambdas/tests/data_providers/sirius/test_authentication.py
+++ b/lambdas/tests/data_providers/sirius/test_authentication.py
@@ -2,27 +2,49 @@ import os
 import json
 import pytest
 import responses
+from unittest import mock
 from requests import Request
 from data_providers.sirius import SiriusAuthenticator, SiriusAuthenticationError
 
 
 class TestSiriusAuthenticator(object):
 
-    def teardown_method(self, method):
-        # Remove the environment variables after each method
-        if 'CREDENTIALS' in os.environ:
-            del os.environ['CREDENTIALS']
-        if 'URL_MEMBRANE' in os.environ:
-            del os.environ['URL_MEMBRANE']
+    # -------------------------------------
+    # Factory tests
 
-    def test_successful_authentication(self):
-        credentials = {'email': 'test@example.com', 'password': 'password'}
+    @mock.patch.dict('os.environ', {'URL_MEMBRANE': 'https://example.com'})
+    @mock.patch.dict('os.environ', {'DYNAMODB_AUTH_CACHE_TABE_NAME': 'tabme-name'})
+    def test_factory_without_credentials(self):
+        with pytest.raises(RuntimeError, match=r'.*CREDENTIALS.*'):
+            SiriusAuthenticator.factory()
 
-        os.environ['CREDENTIALS'] = json.dumps(credentials)
-        os.environ['URL_MEMBRANE'] = 'https://example.com'
+    @mock.patch.dict('os.environ', {'DYNAMODB_AUTH_CACHE_TABE_NAME': 'tabme-name'})
+    @mock.patch.dict('os.environ', {'CREDENTIALS': json.dumps({'email': 'test@example.com', 'password': 'password'})})
+    def test_factory_without_url(self):
+        with pytest.raises(RuntimeError, match=r'.*URL_MEMBRANE.*'):
+            SiriusAuthenticator.factory()
+
+    @mock.patch.dict('os.environ', {'URL_MEMBRANE': 'https://example.com'})
+    @mock.patch.dict('os.environ', {'CREDENTIALS': json.dumps({'email': 'test@example.com', 'password': 'password'})})
+    def test_factory_db_table_name(self):
+        with pytest.raises(RuntimeError, match=r'.*DYNAMODB_AUTH_CACHE_TABE_NAME.*'):
+            SiriusAuthenticator.factory()
+
+    # -------------------------------------
+    # Object tests
+
+    @mock.patch('data_providers.sirius.authentication.boto3', autospec=True)
+    @mock.patch.dict('os.environ', {'URL_MEMBRANE': 'https://example.com'})
+    @mock.patch.dict('os.environ', {'DYNAMODB_AUTH_CACHE_TABE_NAME': 'tabme-name'})
+    @mock.patch.dict('os.environ', {'CREDENTIALS': json.dumps({'email': 'test@example.com', 'password': 'password'})})
+    def test_valid_creds_fresh_token(self, mock_boto3):
+
+        """
+        We have valid creds and want a fresh token.
+        Authentication succeeds
+        """
 
         with responses.RequestsMock() as rsps:
-
             test_token = '~token~'
 
             rsps.add(
@@ -30,23 +52,152 @@ class TestSiriusAuthenticator(object):
                 status=201, json={'authentication_token': test_token}
             )
 
-            a = SiriusAuthenticator.factory()
+            authenticator = SiriusAuthenticator.factory()
 
-            r = a.authorise_request(Request())
+            r, cached_token = authenticator.authorise_request(Request(), accept_cached_token=False)
+
+            # We expect a fresh token.
+            assert cached_token is False
 
             assert isinstance(r, Request)
-
             assert 'HTTP-SECURE-TOKEN' in r.headers
             assert r.headers['HTTP-SECURE-TOKEN'] == test_token
 
-    def test_without_credentials(self):
-        os.environ['URL_MEMBRANE'] = 'https://example.com'
+            # Check we didn't try to access the cache (the wanted a fresh token)
+            mock_boto3.resource.return_value.Table.return_value.get_item.assert_not_called()
 
-        with pytest.raises(RuntimeError, match=r'.*CREDENTIALS.*'):
-            SiriusAuthenticator.factory()
+            # Check the returned token was stored in DynamoDB.
+            mock_boto3.resource.return_value.Table.return_value.put_item.assert_called_once_with(
+                Item={'id': 'token','token': test_token}
+            )
 
-    def test_without_url(self):
-        os.environ['CREDENTIALS'] = json.dumps({'email': 'test@example.com', 'password': 'password'})
+    @mock.patch('data_providers.sirius.authentication.boto3', autospec=True)
+    @mock.patch.dict('os.environ', {'URL_MEMBRANE': 'https://example.com'})
+    @mock.patch.dict('os.environ', {'DYNAMODB_AUTH_CACHE_TABE_NAME': 'tabme-name'})
+    @mock.patch.dict('os.environ', {'CREDENTIALS': json.dumps({'email': 'test@example.com', 'password': 'password'})})
+    def test_invalid_creds_fresh_token(self,mock_boto3):
 
-        with pytest.raises(RuntimeError, match=r'.*URL_MEMBRANE.*'):
-            SiriusAuthenticator.factory()
+        """
+        We have invalid creds and want a fresh token.
+        Authentication fails
+        """
+
+        with responses.RequestsMock() as rsps:
+
+            rsps.add(
+                rsps.POST, os.environ['URL_MEMBRANE'] + '/auth/sessions',
+                status=401, json={}
+            )
+
+            authenticator = SiriusAuthenticator.factory()
+
+            with pytest.raises(SiriusAuthenticationError):
+                authenticator.authorise_request(Request(), accept_cached_token=False)
+
+            # Check we didn't didn't do anything with the cache
+            mock_boto3.resource.return_value.Table.return_value.get_item.assert_not_called()
+            mock_boto3.resource.return_value.Table.return_value.put_item.assert_not_called()
+
+    @mock.patch('data_providers.sirius.authentication.boto3', autospec=True)
+    @mock.patch.dict('os.environ', {'URL_MEMBRANE': 'https://example.com'})
+    @mock.patch.dict('os.environ', {'DYNAMODB_AUTH_CACHE_TABE_NAME': 'tabme-name'})
+    @mock.patch.dict('os.environ', {'CREDENTIALS': json.dumps({'email': 'test@example.com', 'password': 'password'})})
+    def test_invalid_creds_cache_miss_token(self,mock_boto3):
+
+        """
+        We have invalid creds and want a cached token. But there's no token in the cache.
+        Authentication fails
+        """
+
+        with responses.RequestsMock() as rsps:
+
+            rsps.add(
+                rsps.POST, os.environ['URL_MEMBRANE'] + '/auth/sessions',
+                status=401, json={}
+            )
+
+            authenticator = SiriusAuthenticator.factory()
+
+            with pytest.raises(SiriusAuthenticationError):
+                authenticator.authorise_request(Request(), accept_cached_token=True)
+
+            # Check that we looked up the item in the cache.
+            mock_boto3.resource.return_value.Table.return_value.get_item.assert_called_once()
+
+            # But as nothing was return, we try to get a fresh token.
+
+            # But as that fails, we don't try and add anything to the cache.
+            mock_boto3.resource.return_value.Table.return_value.put_item.assert_not_called()
+
+    @mock.patch('data_providers.sirius.authentication.boto3', autospec=True)
+    @mock.patch.dict('os.environ', {'URL_MEMBRANE': 'https://example.com'})
+    @mock.patch.dict('os.environ', {'DYNAMODB_AUTH_CACHE_TABE_NAME': 'tabme-name'})
+    @mock.patch.dict('os.environ', {'CREDENTIALS': json.dumps({'email': 'test@example.com', 'password': 'password'})})
+    def test_valid_creds_cache_miss_token(self,mock_boto3):
+
+        """
+        We have valid creds and want a cached token. But there's no token in the cache.
+        As we have valid creds though, we get a fresh one back instead.
+        Authentication succeeds
+        """
+
+        with responses.RequestsMock() as rsps:
+            test_token = '~token~'
+
+            rsps.add(
+                rsps.POST, os.environ['URL_MEMBRANE'] + '/auth/sessions',
+                status=201, json={'authentication_token': test_token}
+            )
+
+            authenticator = SiriusAuthenticator.factory()
+            r, cached_token = authenticator.authorise_request(Request(), accept_cached_token=True)
+
+            # Check that we looked up the item in the cache.
+            mock_boto3.resource.return_value.Table.return_value.get_item.assert_called_once()
+
+            # But as nothing was return, we try to get a fresh token.
+
+            # Which works, so we should call put_item
+            mock_boto3.resource.return_value.Table.return_value.put_item.assert_called_once_with(
+                Item={'id': 'token','token': test_token}
+            )
+
+            # As we couldn't get a token from the cache, we got a fresh one. Thus cached_token = false.
+            assert cached_token is False
+
+            assert isinstance(r, Request)
+            assert 'HTTP-SECURE-TOKEN' in r.headers
+            assert r.headers['HTTP-SECURE-TOKEN'] == test_token
+
+    @mock.patch('data_providers.sirius.authentication.boto3', autospec=True)
+    @mock.patch.dict('os.environ', {'URL_MEMBRANE': 'https://example.com'})
+    @mock.patch.dict('os.environ', {'DYNAMODB_AUTH_CACHE_TABE_NAME': 'tabme-name'})
+    @mock.patch.dict('os.environ', {'CREDENTIALS': json.dumps({'email': 'test@example.com', 'password': 'password'})})
+    def test_cache_hit_token(self,mock_boto3):
+
+        """
+        We want a cached token and there is one available. That token is returned.
+        Authentication succeeds
+        """
+
+        with responses.RequestsMock() as rsps:
+            test_token = '~token~'
+
+            # Return a valid item from the cache.
+            mock_boto3.resource.return_value.Table.return_value.get_item.return_value = {
+                'Item': {'id': 'token', 'token': test_token}
+            }
+
+            authenticator = SiriusAuthenticator.factory()
+
+            r, cached_token = authenticator.authorise_request(Request(), accept_cached_token=True)
+
+            # We expect a fresh token.
+            assert cached_token is True
+
+            assert isinstance(r, Request)
+            assert 'HTTP-SECURE-TOKEN' in r.headers
+            assert r.headers['HTTP-SECURE-TOKEN'] == test_token
+
+            # Nothing new should have tried to be put into teh cache
+            mock_boto3.resource.return_value.Table.return_value.put_item.assert_not_called()

--- a/lambdas/tests/data_providers/test_sirius_provider.py
+++ b/lambdas/tests/data_providers/test_sirius_provider.py
@@ -2,33 +2,18 @@ import os
 import json
 import responses
 from data_providers import SiriusProvider, Response
+from unittest import mock
+
 
 class TestSiriusProvider(object):
 
-    def setup_method(self, method):
-        credentials = {'email': 'test@example.com', 'password': 'password'}
-        os.environ['CREDENTIALS'] = json.dumps(credentials)
-        os.environ['URL_MEMBRANE'] = 'https://example.com'
-
-    def teardown_method(self, method):
-        # Remove the environment variables after each method
-        if 'CREDENTIALS' in os.environ:
-            del os.environ['CREDENTIALS']
-        if 'URL_MEMBRANE' in os.environ:
-            del os.environ['URL_MEMBRANE']
-
-    def test_the_thing(self):
-
+    @mock.patch('data_providers.sirius.SiriusAuthenticator', autospec=True)
+    @mock.patch.dict('os.environ', {'URL_MEMBRANE': 'https://example.com'})
+    @mock.patch.dict('os.environ', {'CREDENTIALS': json.dumps({'email': 'test@example.com', 'password': 'password'})})
+    def test_a_lookup(self, mock_authenticator):
         with responses.RequestsMock() as rsps:
 
             ident = 'A00000000001'
-            test_token = '~token~'
-
-            # For the auth
-            rsps.add(
-                rsps.POST, os.environ['URL_MEMBRANE'] + '/auth/sessions',
-                status=201, json={'authentication_token': test_token}
-            )
 
             # For the data lookup
             rsps.add(
@@ -36,9 +21,20 @@ class TestSiriusProvider(object):
                 status=200, json=[]
             )
 
-            p = SiriusProvider.factory()
+            # ---
+            # Mock the authenticator
+
+            def side_effect(req, accept_cached_token):
+                return req, accept_cached_token
+
+            mock_authenticator.authorise_request = mock.MagicMock(side_effect=side_effect)
+
+            # ---
+
+            p = SiriusProvider(mock_authenticator, os.environ['URL_MEMBRANE'])
 
             result = p.get_lpa_by_lpa_online_tool_id(ident)
 
             assert isinstance(result, Response)
             assert result.is_empty()
+            mock_authenticator.authorise_request.assert_called_once()

--- a/lambdas/tests/data_providers/test_sirius_provider.py
+++ b/lambdas/tests/data_providers/test_sirius_provider.py
@@ -1,7 +1,8 @@
 import os
 import json
 import responses
-from data_providers import SiriusProvider, Response
+import pytest
+from data_providers import SiriusProvider, Response, UpstreamExceptionError
 from unittest import mock
 
 
@@ -10,7 +11,13 @@ class TestSiriusProvider(object):
     @mock.patch('data_providers.sirius.SiriusAuthenticator', autospec=True)
     @mock.patch.dict('os.environ', {'URL_MEMBRANE': 'https://example.com'})
     @mock.patch.dict('os.environ', {'CREDENTIALS': json.dumps({'email': 'test@example.com', 'password': 'password'})})
-    def test_a_lookup(self, mock_authenticator):
+    def test_get_lpa_by_lpa_online_tool_id_with_first_time_valid_token(self, mock_authenticator):
+
+        """
+        Success Route. Looks up an LPA. Results in a 200 first time.
+        We get back the expected result. The first requested token from the authenticator worked.
+        """
+
         with responses.RequestsMock() as rsps:
 
             ident = 'A00000000001'
@@ -24,10 +31,10 @@ class TestSiriusProvider(object):
             # ---
             # Mock the authenticator
 
-            def side_effect(req, accept_cached_token):
-                return req, accept_cached_token
+            def authorise_request_response(req, accept_cached_token):
+                return req, False
 
-            mock_authenticator.authorise_request = mock.MagicMock(side_effect=side_effect)
+            mock_authenticator.authorise_request = mock.MagicMock(side_effect=authorise_request_response)
 
             # ---
 
@@ -38,3 +45,144 @@ class TestSiriusProvider(object):
             assert isinstance(result, Response)
             assert result.is_empty()
             mock_authenticator.authorise_request.assert_called_once()
+
+    @mock.patch('data_providers.sirius.SiriusAuthenticator', autospec=True)
+    @mock.patch.dict('os.environ', {'URL_MEMBRANE': 'https://example.com'})
+    @mock.patch.dict('os.environ', {'CREDENTIALS': json.dumps({'email': 'test@example.com', 'password': 'password'})})
+    def test_get_lpa_by_lpa_online_tool_id_with_second_time_valid_token(self, mock_authenticator):
+
+        """
+        Success Route, but with the token needing refreshed.
+        Results in a 200 on the second attempt, a 401 on the first.
+        We get back the expected result. The *second* requested token from the authenticator worked.
+        """
+
+        with responses.RequestsMock() as rsps:
+
+            ident = 'A00000000001'
+
+            # ---
+
+            # First we're going to return a 401
+            # Then next a 200
+            lookup_http_response_response_order = [401, 200]
+
+            def lookup_http_response(request):
+                return lookup_http_response_response_order.pop(0), {}, json.dumps({})
+
+            rsps.add_callback(
+                rsps.GET, os.environ['URL_MEMBRANE'] + '/api/public/v1/lpas?lpa-online-tool-id=%s' % ident,
+                callback=lookup_http_response, content_type='application/json',
+            )
+
+            # ---
+
+            # First we're going to say the token came from the cache
+            # Then on the next call, that it didn't
+            authorise_request_response_order = [True, False]
+
+            def authorise_request_response(req, accept_cached_token):
+                expected = authorise_request_response_order.pop(0)
+
+                # Confirms that first we accept a token. Then on the second attempt we don't.
+                assert accept_cached_token == expected
+                return req, expected
+
+            mock_authenticator.authorise_request = mock.MagicMock(side_effect=authorise_request_response)
+
+            # ---
+
+            p = SiriusProvider(mock_authenticator, os.environ['URL_MEMBRANE'])
+
+            result = p.get_lpa_by_lpa_online_tool_id(ident)
+
+            assert isinstance(result, Response)
+            assert result.is_empty()
+            assert mock_authenticator.authorise_request.call_count == 2
+
+    @mock.patch('data_providers.sirius.SiriusAuthenticator', autospec=True)
+    @mock.patch.dict('os.environ', {'URL_MEMBRANE': 'https://example.com'})
+    @mock.patch.dict('os.environ', {'CREDENTIALS': json.dumps({'email': 'test@example.com', 'password': 'password'})})
+    def test_get_lpa_by_lpa_online_tool_id_with_no_valid_token(self, mock_authenticator):
+
+        """
+        Failure route. We get an unauthorised response on both attempts.
+        Two attempts are made as the first token it returned from the cache. The second is fresh. Both fail.
+        """
+
+        with responses.RequestsMock() as rsps:
+
+            ident = 'A00000000001'
+
+            # First we're going to return a 401
+            # Then next a 200
+            lookup_http_response_response_order = [401, 401]
+
+            def lookup_http_response(request):
+                return lookup_http_response_response_order.pop(0), {}, json.dumps({})
+
+            rsps.add_callback(
+                rsps.GET, os.environ['URL_MEMBRANE'] + '/api/public/v1/lpas?lpa-online-tool-id=%s' % ident,
+                callback=lookup_http_response, content_type='application/json',
+            )
+
+            # ---
+
+            # First we're going to say the token came from the cache
+            # Then on the next call, that it didn't
+            authorise_request_response_order = [True, False]
+
+            def authorise_request_response(req, accept_cached_token):
+                return req, authorise_request_response_order.pop(0)
+
+            mock_authenticator.authorise_request = mock.MagicMock(side_effect=authorise_request_response)
+
+            # ---
+
+            p = SiriusProvider(mock_authenticator, os.environ['URL_MEMBRANE'])
+
+            # We expect an exception to be throw
+            with pytest.raises(UpstreamExceptionError):
+                p.get_lpa_by_lpa_online_tool_id(ident)
+
+            # We expect two attempts at getting a valid session
+            assert mock_authenticator.authorise_request.call_count == 2
+
+    @mock.patch('data_providers.sirius.SiriusAuthenticator', autospec=True)
+    @mock.patch.dict('os.environ', {'URL_MEMBRANE': 'https://example.com'})
+    @mock.patch.dict('os.environ', {'CREDENTIALS': json.dumps({'email': 'test@example.com', 'password': 'password'})})
+    def test_get_lpa_by_lpa_online_tool_id_with_no_valid_token_and_no_cached_token(self, mock_authenticator):
+
+        """
+        Failure route. We get an unauthorised response after one attempt.
+        Only one attempt is made as the first token returned is fresh.
+        """
+
+        with responses.RequestsMock() as rsps:
+
+            ident = 'A00000000001'
+
+            # For the data lookup
+            rsps.add(
+                rsps.GET, os.environ['URL_MEMBRANE'] + '/api/public/v1/lpas?lpa-online-tool-id=%s' % ident,
+                status=401, json=[]
+            )
+
+            # ---
+            # Mock the authenticator
+
+            def authorise_request_response(req, accept_cached_token):
+                return req, False
+
+            mock_authenticator.authorise_request = mock.MagicMock(side_effect=authorise_request_response)
+
+            # ---
+
+            p = SiriusProvider(mock_authenticator, os.environ['URL_MEMBRANE'])
+
+            # We expect an exception to be throw
+            with pytest.raises(UpstreamExceptionError):
+                p.get_lpa_by_lpa_online_tool_id(ident)
+
+            # We expect only one attempt as teh first token returned was 'fresh'.
+            assert mock_authenticator.authorise_request.call_count == 1

--- a/localstack-config/Dockerfile
+++ b/localstack-config/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:alpine
+
+RUN pip install awscli
+
+ENV WAITFORIT_VERSION="v2.4.1"
+RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxcnunes/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
+  && chmod +x /usr/local/bin/waitforit
+
+RUN mkdir /config
+WORKDIR /config
+
+# Deliberately empty. Needed by the AWS CLI.
+ENV AWS_ACCESS_KEY_ID = ''
+ENV AWS_SECRET_ACCESS_KEY = ''
+
+CMD chmod +x /config/*.sh \
+    && /config/config.sh

--- a/localstack-config/config.sh
+++ b/localstack-config/config.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+#
+#  Setup DynamoDB
+#
+/usr/local/bin/waitforit -address=tcp://gateway-localstack:4569 -timeout 60 -retry 6000 -debug
+
+if [ $? -ne 0 ]; then
+    echo "DynamoDB failed to start"
+else
+    aws dynamodb create-table \
+    --attribute-definitions AttributeName=id,AttributeType=S \
+    --table-name opg-gateway-cache-auth \
+    --key-schema AttributeName=id,KeyType=HASH \
+    --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10 \
+    --region eu-west-1 \
+    --endpoint http://gateway-localstack:4569
+fi

--- a/lpas_collection.tf
+++ b/lpas_collection.tf
@@ -32,6 +32,7 @@ module "lpas_collection_lambda" {
     variables {
       CREDENTIALS  = "${data.aws_secretsmanager_secret_version.sirius_credentials.secret_string}"
       URL_MEMBRANE = "https://${local.membrane_hostname}"
+      DYNAMODB_AUTH_CACHE_TABE_NAME = "${aws_dynamodb_table.auth_cache.name}"
     }
   }
 

--- a/lpas_collection.tf
+++ b/lpas_collection.tf
@@ -28,6 +28,8 @@ module "lpas_collection_lambda" {
 
   vpc = "${local.vpc_name}"
 
+  dynamodb_auth_cache_table = "${aws_dynamodb_table.auth_cache.arn}"
+
   environment {
     variables {
       CREDENTIALS  = "${data.aws_secretsmanager_secret_version.sirius_credentials.secret_string}"

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -35,6 +35,24 @@ resource "aws_iam_role_policy_attachment" "aws_lambda_vpc_access_execution_role"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
+data "aws_iam_policy_document" "iam_for_lambda_inline_execution_role" {
+  statement {
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+    ]
+    resources = [
+      "${var.dynamodb_auth_cache_table}",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "iam_for_lambda_inline_execution_role" {
+  name = "ViewerApplicationPermissions"
+  policy = "${data.aws_iam_policy_document.iam_for_lambda_inline_execution_role.json}"
+  role   = "${aws_iam_role.iam_for_lambda.id}"
+}
+
 data "aws_iam_policy_document" "lambda_assume" {
   statement {
     sid = "OPGAPIGatewayLambdaInvoke"

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -30,3 +30,7 @@ variable "environment" {
   type        = "map"
   default     = {}
 }
+
+variable "dynamodb_auth_cache_table" {
+  description = "The ARN of the DynamoDb table in which we cache auth tokens"
+}

--- a/simulate_sirius_access.tf
+++ b/simulate_sirius_access.tf
@@ -13,6 +13,8 @@ module "sirius_access_test_lambda" {
 
   vpc = "${local.vpc_name}"
 
+  dynamodb_auth_cache_table = "${aws_dynamodb_table.auth_cache.arn}"
+
   environment {
     variables {
       CREDENTIALS = "${data.aws_secretsmanager_secret_version.sirius_credentials.secret_string}"


### PR DESCRIPTION
# Description

Adds auth token caching to the lambda.
Includes a DynamoDB table to cache the token in.

# Contribution Checklist

- [x] Terraform plans
