### PR TITLE
LPA-3217: Exit with an error if authentication fails

### DIFF
--- a/lambdas/simulate_sirius_access.py
+++ b/lambdas/simulate_sirius_access.py
@@ -44,3 +44,4 @@ def test_handler(event, context):
     else:
         print('Login failed')
         pprint.pprint(r.text)
+        exit(4)


### PR DESCRIPTION
# Issues Resolved

An error return code was missing. This resulted in the test not picking up the error when authentication failed.

# Contribution Checklist

- [x] Terraform plans
