### PR TITLE
Updated cache config

### DIFF
--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -11,6 +11,10 @@ resource "aws_dynamodb_table" "auth_cache" {
   }
 
   tags = "${local.default_tags}"
+
+  server_side_encryption {
+    enabled = true
+  }
 }
 
 resource "aws_dynamodb_table" "data_cache" {
@@ -30,4 +34,8 @@ resource "aws_dynamodb_table" "data_cache" {
   }
 
   tags = "${local.default_tags}"
+
+  server_side_encryption {
+    enabled = true
+  }
 }

--- a/lambdas/data_providers/cache/dynamodb.py
+++ b/lambdas/data_providers/cache/dynamodb.py
@@ -23,7 +23,7 @@ class CacheProviderWrapper:
 
     # TTL used for DynamoDB
     # Note DynamoDB doesn't guarantee it'll be deleted exactly as the TTL expires; just soon after.
-    CACHE_TTL = relativedelta(hours=1)
+    CACHE_TTL = relativedelta(hours=48)
 
     def __init__(self, data_provider):
         self._data_provider = data_provider

--- a/lambdas/lpas_collection.py
+++ b/lambdas/lpas_collection.py
@@ -4,10 +4,13 @@ from rest_collections import InvalidInputError, LpasCollection
 from data_providers import UpstreamExceptionError, UpstreamTimeoutError, InternalExceptionError
 import traceback
 import json
+import os
 import logging
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
+
+if 'ENABLE_DEBUG' in os.environ and os.environ['ENABLE_DEBUG'] == 'true':
+    logger.setLevel(logging.DEBUG)
 
 
 def id_handler(event, context):


### PR DESCRIPTION
# Description

As per the conversion with @mattmachell, this:
- Uses KMS encryption on the DynamoDB tables; and
- Sets the data cache's TTL t0 48 hours.

# Contribution Checklist

- [x] Terraform plans
- [ ] New functionality has been documented in the README if applicable
