### PR TITLE
Default log level is too low, set to INFO

### DIFF
--- a/lambdas/lpas_collection.py
+++ b/lambdas/lpas_collection.py
@@ -11,6 +11,8 @@ logger = logging.getLogger()
 
 if 'ENABLE_DEBUG' in os.environ and os.environ['ENABLE_DEBUG'] == 'true':
     logger.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.INFO)
 
 
 def id_handler(event, context):


### PR DESCRIPTION
# Issues Resolved

The default Python log level wasn't including messages set to INFO.

It's now explicitly set so we get those logs.
