### PR TITLE
Disable threads on Flask

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -8,4 +8,4 @@ echo "Ensuring the Lambda has its dependencies"
 pip3 install -r /srv/lambdas/requirements.txt  --target /srv/lambdas/vendor
 
 echo "Starting Mock API Gateway"
-python -m flask run --host=0.0.0.0
+python -m flask run --host=0.0.0.0 --without-threads


### PR DESCRIPTION
This ensures that we don't end up with multiple lambci containers trying to bind to the same port simultaneously.