### PR TITLE
Fix gateway context

### DIFF
--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -2,6 +2,8 @@ version: '2.1'
 
 services:
   gateway:
+    build:
+      context: ../opg-sirius-api-gateway/
     volumes:
       - ../opg-sirius-api-gateway/docker:/srv/docker:cached
       - ../opg-sirius-api-gateway/lambdas:/srv/lambdas:cached

--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -14,7 +14,7 @@ services:
       PASSTHROUGH_URL_MEMBRANE: https://membrane
       # Non-secret credentials, deliberately committed.
       PASSTHROUGH_CREDENTIALS: '{"email": "publicapi@opgtest.com","password": "Password1"}'
-      PASSTHROUGH_ENABLE_DEBUG: 'true'
+      PASSTHROUGH_ENABLE_DEBUG: 'false'
       PASSTHROUGH_DATA_PROVIDER: json
 
   localstack-config:

--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -15,6 +15,7 @@ services:
       # Non-secret credentials, deliberately committed.
       PASSTHROUGH_CREDENTIALS: '{"email": "publicapi@opgtest.com","password": "Password1"}'
       PASSTHROUGH_ENABLE_DEBUG: 'true'
+      PASSTHROUGH_DATA_PROVIDER: json
 
   localstack-config:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       PASSTHROUGH_DYNAMODB_DATA_CACHE_TABLE_NAME: opg-gateway-cache-data
       PASSTHROUGH_DYNAMODB_AUTH_CACHE_TABLE_NAME: opg-gateway-cache-auth
       PASSTHROUGH_AWS_ENDPOINT_DYNAMODB: http://gateway-localstack:14569
+      PASSTHROUGH_ENABLE_DEBUG: 'true'
 
   gateway-localstack:
     image: localstack/localstack


### PR DESCRIPTION
# Description

- Set the correct Gateway context when building for an integration.
- Default to the JSON provider for an integration.
- Default to DEBUG being off for an integration. 
