### PR TITLE
Added flag to disable Sirius Data Provider

### DIFF
--- a/lambdas/README.md
+++ b/lambdas/README.md
@@ -17,6 +17,7 @@ Each function should have its own Python file in the root of this directory.
 * `DYNAMODB_DATA_CACHE_TABLE_NAME`: Required if `DISABLE_DATA_CACHE` is false. The name of the DynamoDB table in which to cache responses.
 * `DYNAMODB_AUTH_CACHE_TABLE_NAME`: Required if `DATA_PROVIDER` is 'sirius'. The name of the DynamoDB table in which to cache authentication tokens.
 * `AWS_ENDPOINT_DYNAMODB`: Optional. For use when testing locally. Set the value to the URL for Localstack's DynamoDB. Defaults to AWS's SDK's defaults.
+* `DISABLE_SIRIUS_LOOKUP`: Optional. If set to `'true'`, the Sirius data provider will always return an Upstream Exception. Defaults to `'false'`.
 
 ### Packaging for deployment to Lambda
 

--- a/lambdas/data_providers/sirius_provider.py
+++ b/lambdas/data_providers/sirius_provider.py
@@ -43,7 +43,8 @@ class SiriusProvider:
         logging.info("Sirius lookup of %s" % id_value)
 
         if self._force_return_upstream_exception_error:
-            logging.warning("The Sirius data provider is currently set to always return None. Returning straight away.")
+            logging.warning("The Sirius data provider is currently set to always return an UpstreamExceptionError. "
+                            "Returning straight away.")
             raise UpstreamExceptionError('Provider disabled.')
 
         try:

--- a/lpas_collection.tf
+++ b/lpas_collection.tf
@@ -37,6 +37,7 @@ module "lpas_collection_lambda" {
       URL_MEMBRANE = "https://${local.membrane_hostname}"
       DYNAMODB_AUTH_CACHE_TABLE_NAME = "${aws_dynamodb_table.auth_cache.name}"
       DYNAMODB_DATA_CACHE_TABLE_NAME = "${aws_dynamodb_table.data_cache.name}"
+      DISABLE_SIRIUS_LOOKUP = "true"
     }
   }
 

--- a/lpas_collection.tf
+++ b/lpas_collection.tf
@@ -37,7 +37,7 @@ module "lpas_collection_lambda" {
       URL_MEMBRANE = "https://${local.membrane_hostname}"
       DYNAMODB_AUTH_CACHE_TABLE_NAME = "${aws_dynamodb_table.auth_cache.name}"
       DYNAMODB_DATA_CACHE_TABLE_NAME = "${aws_dynamodb_table.data_cache.name}"
-      DISABLE_SIRIUS_LOOKUP = "true"
+      DISABLE_SIRIUS_LOOKUP = "false" // true to enable
     }
   }
 


### PR DESCRIPTION
# Description

Allows the Sirius Data Provider to instantly return an Upstream Exception if a flag is set.