### PR TITLE
add rich to list of users who can invoke the api gateway

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -85,6 +85,7 @@ locals {
     "arn:aws:iam::631181914621:user/andrew.pearce",
     "arn:aws:iam::631181914621:user/neil.smith",
     "arn:aws:iam::631181914621:user/adam.cooper",
+    "arn:aws:iam::631181914621:user/richard.mchale ",
   ]
 
   default_tags = {

--- a/locals.tf
+++ b/locals.tf
@@ -85,7 +85,7 @@ locals {
     "arn:aws:iam::631181914621:user/andrew.pearce",
     "arn:aws:iam::631181914621:user/neil.smith",
     "arn:aws:iam::631181914621:user/adam.cooper",
-    "arn:aws:iam::631181914621:user/richard.mchale ",
+    "arn:aws:iam::631181914621:user/richard.mchale",
   ]
 
   default_tags = {


### PR DESCRIPTION
# Description
Add Rich as a user who can assume the sirius-api-gateway-access-use-an-lpa role and invoke the api gateway
