### PR TITLE
update docker-compose version to 3.7 to match opg-lpa

### DIFF
--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '3.7'
 
 services:
   gateway:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '3.7'
 
 services:
   gateway:


### PR DESCRIPTION
# Description

Updates the version of docker-compose.

# Issues Resolved

The opg-lpa repository uses docker-compose 3.7 to take advantage of some new features. When we bring up api gateway from our own docker-compose we get a version mismatch error.
![image](https://user-images.githubusercontent.com/6545556/77082059-79397700-69f3-11ea-9088-fe8d26d05b0e.png)
# Contribution Checklist

- [ ] Terraform plans
- [ ] New functionality has been documented in the README if applicable
