### PR TITLE
Lpa 3620

### DIFF
--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.1'
 
 services:
   gateway:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2.1'
 
 services:
   gateway:

--- a/locals.tf
+++ b/locals.tf
@@ -50,12 +50,12 @@ locals {
 
   online_lpa_tool_development_api_gateway_allowed_roles = [
     "arn:aws:iam::001780581745:root",
-    "arn:aws:iam::050256574573:root", // ecs lpa dev
+    "arn:aws:iam::050256574573:root",                             // ecs lpa dev
+    "arn:aws:iam::987830934591:role/preproduction-api-task-role", // ecs lpa preprod
   ]
 
   online_lpa_tool_production_api_gateway_allowed_roles = [
-    "arn:aws:iam::987830934591:role/preproduction-api-task-role", // ecs lpa preprod
-    "arn:aws:iam::980242665824:role/production-api-task-role",    // ecs lpa prod
+    "arn:aws:iam::980242665824:role/production-api-task-role", // ecs lpa prod
   ]
 
   api_gateway_allowed_roles_online_lpa_tool = "${split(",", terraform.workspace == "development" ? join(",", local.online_lpa_tool_development_api_gateway_allowed_roles) : join(",", local.online_lpa_tool_production_api_gateway_allowed_roles))}"

--- a/locals.tf
+++ b/locals.tf
@@ -49,7 +49,6 @@ locals {
   }
 
   online_lpa_tool_development_api_gateway_allowed_roles = [
-    "arn:aws:iam::001780581745:root",
     "arn:aws:iam::050256574573:root",                             // ecs lpa dev
     "arn:aws:iam::987830934591:role/preproduction-api-task-role", // ecs lpa preprod
   ]


### PR DESCRIPTION
# Description

Make a LPA (MaL) preproduction is not tracking the status of seeded cases from the development Sirius API gateway.

Logs show this is because MaL is not authorised to access that endpoint.

# Approach

Update the lists that define development and production access and point LPA preproduction to the development API gateway.

In addition, 
- set the docker-compose file versions to 2.1 as we are not using any 3.7 features.
- remove access for the legacy MaL development account as it doesn't exist anymore.
