### PR TITLE
allow the ual operator roles to assume the sirius api gateway role. 

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -57,7 +57,7 @@ locals {
 
   online_lpa_tool_production_api_gateway_allowed_roles = [
     "arn:aws:iam::980242665824:role/production-api-task-role", // ecs lpa prod
-    "arn:aws:iam::980242665824:role/breakglass",               // lpa prod operator
+    "arn:aws:iam::980242665824:role/operator",                 // lpa prod operator
   ]
 
   api_gateway_allowed_roles_online_lpa_tool = "${split(",", terraform.workspace == "development" ? join(",", local.online_lpa_tool_development_api_gateway_allowed_roles) : join(",", local.online_lpa_tool_production_api_gateway_allowed_roles))}"
@@ -70,8 +70,8 @@ locals {
   ]
 
   use_an_lpa_production_api_gateway_allowed_roles = [
-    "arn:aws:iam::690083044361:root",            // Prod
-    "arn:aws:iam::690083044361:role/breakglass", // ual prod operator
+    "arn:aws:iam::690083044361:root",          // Prod
+    "arn:aws:iam::690083044361:role/operator", // ual prod operator
   ]
 
   api_gateway_allowed_roles_use_an_lpa = "${split(",", terraform.workspace == "development" ? join(",", local.use_an_lpa_development_api_gateway_allowed_roles) : join(",", local.use_an_lpa_production_api_gateway_allowed_roles))}"

--- a/locals.tf
+++ b/locals.tf
@@ -60,12 +60,15 @@ locals {
   api_gateway_allowed_roles_online_lpa_tool = "${split(",", terraform.workspace == "development" ? join(",", local.online_lpa_tool_development_api_gateway_allowed_roles) : join(",", local.online_lpa_tool_production_api_gateway_allowed_roles))}"
 
   use_an_lpa_development_api_gateway_allowed_roles = [
-    "arn:aws:iam::367815980639:root", // Dev
-    "arn:aws:iam::888228022356:root", // Preprod
+    "arn:aws:iam::367815980639:root",          // Dev
+    "arn:aws:iam::888228022356:root",          // Preprod
+    "arn:aws:iam::367815980639:role/operator", // ual dev operator
+    "arn:aws:iam::888228022356:role/operator", // ual preprod operator
   ]
 
   use_an_lpa_production_api_gateway_allowed_roles = [
-    "arn:aws:iam::690083044361:root", // Prod
+    "arn:aws:iam::690083044361:root",          // Prod
+    "arn:aws:iam::690083044361:role/operator", // ual prod operator
   ]
 
   api_gateway_allowed_roles_use_an_lpa = "${split(",", terraform.workspace == "development" ? join(",", local.use_an_lpa_development_api_gateway_allowed_roles) : join(",", local.use_an_lpa_production_api_gateway_allowed_roles))}"
@@ -77,9 +80,6 @@ locals {
     "arn:aws:iam::631181914621:user/seema.menon",
     "arn:aws:iam::631181914621:user/gemma.taylor",
     "arn:aws:iam::631181914621:user/pam.crosby",
-    "arn:aws:iam::367815980639:role/operator",       // ual dev operator
-    "arn:aws:iam::888228022356:role/operator",       // ual preprod operator
-    "arn:aws:iam::690083044361:role/operator",       // ual prod operator
   ]
 
   default_tags = {

--- a/locals.tf
+++ b/locals.tf
@@ -77,6 +77,9 @@ locals {
     "arn:aws:iam::631181914621:user/seema.menon",
     "arn:aws:iam::631181914621:user/gemma.taylor",
     "arn:aws:iam::631181914621:user/pam.crosby",
+    "arn:aws:iam::367815980639:role/operator",       // ual dev operator
+    "arn:aws:iam::888228022356:role/operator",       // ual preprod operator
+    "arn:aws:iam::690083044361:role/operator",       // ual prod operator
   ]
 
   default_tags = {

--- a/locals.tf
+++ b/locals.tf
@@ -51,7 +51,7 @@ locals {
   online_lpa_tool_development_api_gateway_allowed_roles = [
     "arn:aws:iam::050256574573:root",                             // ecs lpa dev
     "arn:aws:iam::987830934591:role/preproduction-api-task-role", // ecs lpa preprod
-    "arn:aws:iam::050256574573::role/operator",                   // lpa dev operator
+    "arn:aws:iam::050256574573:role/operator",                    // lpa dev operator
     "arn:aws:iam::987830934591:role/operator",                    // lpa preprod operator
   ]
 

--- a/locals.tf
+++ b/locals.tf
@@ -51,10 +51,13 @@ locals {
   online_lpa_tool_development_api_gateway_allowed_roles = [
     "arn:aws:iam::050256574573:root",                             // ecs lpa dev
     "arn:aws:iam::987830934591:role/preproduction-api-task-role", // ecs lpa preprod
+    "arn:aws:iam::050256574573::role/operator",                   // lpa dev operator
+    "arn:aws:iam::987830934591:role/operator",                    // lpa preprod operator
   ]
 
   online_lpa_tool_production_api_gateway_allowed_roles = [
     "arn:aws:iam::980242665824:role/production-api-task-role", // ecs lpa prod
+    "arn:aws:iam::980242665824:role/breakglass",               // lpa prod operator
   ]
 
   api_gateway_allowed_roles_online_lpa_tool = "${split(",", terraform.workspace == "development" ? join(",", local.online_lpa_tool_development_api_gateway_allowed_roles) : join(",", local.online_lpa_tool_production_api_gateway_allowed_roles))}"
@@ -67,8 +70,8 @@ locals {
   ]
 
   use_an_lpa_production_api_gateway_allowed_roles = [
-    "arn:aws:iam::690083044361:root",          // Prod
-    "arn:aws:iam::690083044361:role/operator", // ual prod operator
+    "arn:aws:iam::690083044361:root",            // Prod
+    "arn:aws:iam::690083044361:role/breakglass", // ual prod operator
   ]
 
   api_gateway_allowed_roles_use_an_lpa = "${split(",", terraform.workspace == "development" ? join(",", local.use_an_lpa_development_api_gateway_allowed_roles) : join(",", local.use_an_lpa_production_api_gateway_allowed_roles))}"


### PR DESCRIPTION
# Description

Allow the UaL operator roles to execute the Sirius API gateway.

LPA developers require day to day access to the Sirius API gateway in order to develop and to resolve queries and issues from customers.

# Contribution Checklist

- [x] Terraform plans
- [ ] New functionality has been documented in the README if applicable
