### PR TITLE
Add a configurable endpoint to the config script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       #PASSTHROUGH_DATA_PROVIDER: json  # Uncomment to use the JSON provider.
 
   gateway-localstack:
-    image: localstack/localstack
+    image: localstack/localstack:0.11.5
     ports:
       - 14569:14569
     environment:

--- a/localstack-config/config.sh
+++ b/localstack-config/config.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
+endpoint=${AWS_ENDPOINT_DYNAMODB:-"gateway-localstack:14569"}
+
 #
 #  Setup DynamoDB
 #
-/usr/local/bin/waitforit -address=tcp://gateway-localstack:14569 -timeout 60 -retry 6000 -debug
+/usr/local/bin/waitforit -address=tcp://$endpoint -timeout 60 -retry 6000 -debug
 
 if [ $? -ne 0 ]; then
     echo "DynamoDB failed to start"
@@ -14,7 +16,7 @@ else
     --key-schema AttributeName=id,KeyType=HASH \
     --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10 \
     --region eu-west-1 \
-    --endpoint http://gateway-localstack:14569
+    --endpoint http://$endpoint
 
     aws dynamodb create-table \
     --attribute-definitions AttributeName=id,AttributeType=S \
@@ -22,11 +24,11 @@ else
     --key-schema AttributeName=id,KeyType=HASH \
     --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=10 \
     --region eu-west-1 \
-    --endpoint http://gateway-localstack:14569
+    --endpoint http://$endpoint
 
     aws dynamodb update-time-to-live \
     --table-name opg-gateway-cache-data \
     --time-to-live-specification "Enabled=true, AttributeName=expires" \
     --region eu-west-1 \
-    --endpoint http://gateway-localstack:14569
+    --endpoint http://$endpoint
 fi


### PR DESCRIPTION
Adds an environment variable to the configuration container and sets the default to the original value

# Description
Allows the configuration of the localstack when using newer versions by providing an environment variable that can be used to specify the endpoint at which the localstack dynamodb is running.

# Issues Resolved
Lets projects use a new version of localstack and api-gateway whilst retaining backwards compatibility.

# Contribution Checklist

- [ ] Terraform plans
- [ ] New functionality has been documented in the README if applicable
