### PR TITLE
Optional dates should be marked as nullable in Swagger doc

### DIFF
--- a/docs/swagger.v1.yaml
+++ b/docs/swagger.v1.yaml
@@ -60,11 +60,13 @@ paths:
                   cancellationDate:
                     type: string
                     format: date
+                    nullable: true
                     description: The date the LPA was cancelled
                     example: '2018-06-30'
                   invalidDate:
                     type: string
                     format: date
+                    nullable: true
                     description: The date the LPA was marked invalid
                     example: '2018-06-30'
                   receiptDate:


### PR DESCRIPTION
cancellationDate and invalidDate should be marked as nullable
as they are only set for LPAs marked as cancelled or invalid.

# Description

Makes the Swagger doc align with the data available for an LPA.

# Issues Resolved

n/a

# Contribution Checklist

- [ ] Terraform plans
- [ ] New functionality has been documented in the README if applicable
